### PR TITLE
fix shell "(" expected error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # powercfg_generator
 # by cjybyjk @ coolapk
 # License: GPL v3


### PR DESCRIPTION
Using /bin/sh will cause 

./start.sh: 8: ./start.sh: source: not found
./start.sh: 10: ./start.sh: Syntax error: "(" unexpected

applying bash will fix it